### PR TITLE
Implement multi stream attach

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -57,7 +57,8 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 			auto id = this->allocate_id();
 			hook_entries[id] = nv_attach_entry{
 				.type = nv_attach_cuda_memcapture{},
-				.instuctions = data.instructions
+				.instuctions = data.instructions,
+				.kernels = data.func_names
 			};
 			this->map_basic_info = data.map_basic_info;
 			this->shared_mem_ptr = data.comm_shared_mem;
@@ -74,7 +75,8 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 							data.code_addr_or_func_name),
 						.is_retprobe = false,
 					},
-				.instuctions = data.instructions
+				.instuctions = data.instructions,
+				.kernels = data.func_names
 			};
 			this->map_basic_info = data.map_basic_info;
 			this->shared_mem_ptr = data.comm_shared_mem;
@@ -91,7 +93,8 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 						data.code_addr_or_func_name),
 					.is_retprobe = true,
 				},
-			.instuctions = data.instructions
+			.instuctions = data.instructions,
+			.kernels = data.func_names
 		};
 		this->map_basic_info = data.map_basic_info;
 		this->shared_mem_ptr = data.comm_shared_mem;

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -66,6 +66,8 @@ using nv_attach_type =
 struct nv_attach_entry {
 	nv_attach_type type;
 	std::vector<ebpf_inst> instuctions;
+	// Kernels to be patched for this attach entry
+	std::vector<std::string> kernels;
 };
 
 // Attach implementation of syscall trace
@@ -96,7 +98,6 @@ class nv_attach_impl final : public base_attach_impl {
 	int copy_data_to_trampoline_memory();
 	TrampolineMemorySetupStage trampoline_memory_state =
 		TrampolineMemorySetupStage::NotSet;
-
 
     private:
 	void *frida_interceptor;

--- a/attach/nv_attach_impl/nv_attach_private_data.cpp
+++ b/attach/nv_attach_impl/nv_attach_private_data.cpp
@@ -18,13 +18,31 @@ std::string nv_attach_private_data::to_string() const
 		oss << "func_name=" << std::hex
 		    << std::get<std::string>(code_addr_or_func_name) << " ";
 	}
+	if (!func_names.empty()) {
+		oss << "func_names=";
+		for (size_t i = 0; i < func_names.size(); i++) {
+			if (i)
+				oss << ",";
+			oss << func_names[i];
+		}
+		oss << " ";
+	}
 	oss << "comm_shared_mem=" << std::hex << comm_shared_mem << " ";
 	return oss.str();
 };
 
 int nv_attach_private_data::initialize_from_string(const std::string_view &sv)
 {
-	this->code_addr_or_func_name = std::string(sv);
-
+	std::string input{ sv };
+	std::stringstream ss(input);
+	std::string item;
+	while (std::getline(ss, item, ',')) {
+		if (!item.empty())
+			func_names.push_back(item);
+	}
+	if (!func_names.empty())
+		code_addr_or_func_name = func_names.front();
+	else
+		code_addr_or_func_name = input;
 	return 0;
 }

--- a/attach/nv_attach_impl/nv_attach_private_data.hpp
+++ b/attach/nv_attach_impl/nv_attach_private_data.hpp
@@ -11,14 +11,14 @@ namespace bpftime
 namespace attach
 {
 struct nv_attach_private_data final : public attach_private_data {
-
 	std::variant<uintptr_t, std::string> code_addr_or_func_name;
+	// Names of kernels to be patched when multi-stream is used
+	std::vector<std::string> func_names;
 	uintptr_t comm_shared_mem = 0;
 	std::vector<MapBasicInfo> map_basic_info;
 	std::vector<ebpf_inst> instructions;
 	int initialize_from_string(const std::string_view &sv) override;
 	std::string to_string() const override;
-
 };
 
 } // namespace attach


### PR DESCRIPTION
## Summary
- support multi-stream by allowing multiple kernel names in nv_attach_private_data
- store target kernels in nv_attach_entry
- patch multiple kernels in nv_attach_impl_patcher
- record multi-stream info when creating CUDA attach entries

## Testing
- `make build-unit-test-without-probe-check` *(fails: No download info given for 'libbpf' and its source directory)*